### PR TITLE
DEV: add support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ python:
  - "3.5"
  - "3.6"
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 install:
  - pip install -e .[dev]
 


### PR DESCRIPTION


# Test Plan

- [x] Run unit tests in python 3.7 and python 3.6 and observe no failures

## Python 3.7
```bash
(tf1.13) ddn@pca:cloudpickle-generators$ python --version
Python 3.7.0
(tf1.13) ddn@pca:cloudpickle-generators$ pytest cloudpickle_generators
============================================================ test session starts ============================================================
platform darwin -- Python 3.7.0, pytest-4.2.1, py-1.7.0, pluggy-0.8.1
sensitiveurl: .*
rootdir: /Users/ddn/w/cloudpickle-generators, inifile:
plugins: requests-mock-1.5.2, xdist-1.26.1, variables-1.7.1, selenium-1.16.0, metadata-1.8.0, html-1.20.0, forked-1.0.2, cov-2.6.1, base-url-1.4.1, asyncio-0.10.0
collected 11 items

cloudpickle_generators/tests/test_cloudpickle_generators.py ...........                                                               [100%]

========================================================= 11 passed in 0.04 seconds =========================================================
```

## Python 3.6
```bash
(tf1.13) ddn@pca:cloudpickle-generators$ conda activate nvim
(nvim) ddn@pca:cloudpickle-generators$ python --version
Python 3.6.8 :: Anaconda, Inc.
(nvim) ddn@pca:cloudpickle-generators$ pip install -e .
Obtaining file:///Users/ddn/w/cloudpickle-generators
Requirement already satisfied: cloudpickle in /anaconda3/envs/nvim/lib/python3.6/site-packages (from cloudpickle-generators==0.1.0) (0.5.3)
Installing collected packages: cloudpickle-generators
  Found existing installation: cloudpickle-generators 0.1.0
    Uninstalling cloudpickle-generators-0.1.0:
      Successfully uninstalled cloudpickle-generators-0.1.0
  Running setup.py develop for cloudpickle-generators
Successfully installed cloudpickle-generators
(nvim) ddn@pca:cloudpickle-generators$ pytest cloudpickle_generators
============================================================ test session starts ============================================================
platform darwin -- Python 3.6.8, pytest-4.2.1, py-1.7.0, pluggy-0.8.1
sensitiveurl: .*
rootdir: /Users/ddn/w/cloudpickle-generators, inifile:
plugins: requests-mock-1.5.2, xdist-1.26.1, variables-1.7.1, selenium-1.16.0, metadata-1.8.0, html-1.20.0, forked-1.0.1, cov-2.6.1, base-url-1.4.1, asyncio-0.10.0
collected 11 items

cloudpickle_generators/tests/test_cloudpickle_generators.py ...........                                                               [100%]

========================================================= 11 passed in 0.08 seconds =========================================================
```