### PR TITLE
 BUG: make unset_value the sentinel instance, not the type 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ TAGS
 .compiler_flags
 
 *.egg-info/*
+
+venv/*

--- a/cloudpickle_generators/_core.c
+++ b/cloudpickle_generators/_core.c
@@ -15,7 +15,8 @@
 #else
 #define EXC_TYPE_REF(frame) (((PyGenObject*)((frame)->f_gen))->gi_exc_state.exc_type)
 #define EXC_VALUE_REF(frame) (((PyGenObject*)((frame)->f_gen))->gi_exc_state.exc_value)
-#define EXC_TRACEBACK_REF(frame) (((PyGenObject*)((frame)->f_gen))->gi_exc_state.exc_traceback)
+#define EXC_TRACEBACK_REF(frame) \
+  (((PyGenObject*)((frame)->f_gen))->gi_exc_state.exc_traceback)
 #endif
 
 static PyObject* unset_value_repr(PyObject* UNUSED(self)) {
@@ -30,6 +31,15 @@ static void unset_value_dealloc(PyObject* UNUSED(self)) {
 
 PyMethodDef unset_value_methods[] = {
     {"__reduce__", (PyCFunction) unset_value_repr, METH_NOARGS, NULL},
+    {NULL},
+};
+
+PyObject* get_module(PyObject* UNUSED(self), void* UNUSED(arg)) {
+  return PyUnicode_FromString("cloudpickle_generators._core");
+}
+
+PyGetSetDef unset_value_getsets[] = {
+    {"__module__", get_module, NULL, NULL, NULL},
     {NULL},
 };
 
@@ -62,6 +72,8 @@ static PyTypeObject unset_value_type = {
     0,                                                /* tp_coroutine */
     0,                                                /* tp_coroutinenext */
     unset_value_methods,                              /* tp_methods */
+    0,                                                /* tp_members */
+    unset_value_getsets,                              /* tp_getset */
 };
 
 PyObject unset_value = {
@@ -390,7 +402,7 @@ PyInit__core(void) {
 
     if (PyObject_SetAttrString(m,
                                "unset_value",
-                               (PyObject*) &unset_value_type)) {
+                               (PyObject*) &unset_value)) {
         Py_DECREF(m);
         return NULL;
     }

--- a/cloudpickle_generators/tests/conftest.py
+++ b/cloudpickle_generators/tests/conftest.py
@@ -1,0 +1,3 @@
+import cloudpickle_generators
+
+cloudpickle_generators.register()

--- a/cloudpickle_generators/tests/test_cloudpickle_generators.py
+++ b/cloudpickle_generators/tests/test_cloudpickle_generators.py
@@ -3,10 +3,6 @@ from types import FunctionType
 
 import cloudpickle
 
-import cloudpickle_generators
-
-cloudpickle_generators.register()
-
 
 def roundtrip(ob):
     return cloudpickle.loads(cloudpickle.dumps(ob))

--- a/cloudpickle_generators/tests/test_unset_value.py
+++ b/cloudpickle_generators/tests/test_unset_value.py
@@ -1,0 +1,21 @@
+import cloudpickle
+import pytest
+
+from cloudpickle_generators import unset_value
+
+
+def roundtrip(ob):
+    return cloudpickle.loads(cloudpickle.dumps(ob))
+
+
+def test_pickleable():
+    assert roundtrip(unset_value) is unset_value
+
+
+def test_repr():
+    assert repr(unset_value) == 'unset_value'
+
+
+def test_unique():
+    with pytest.raises(TypeError):
+        type(unset_value)()


### PR DESCRIPTION
`cloudpickle_generators.unset_value` was being set to the `unset_value_type`,
not the `unset_value` sentinel instance. Because
`cloudpickle._core.unset_value_type` didn't exist (and refer to
`unset_value_type`), cloudpickle thought this was a dynamic class and serialized
the class and all of it's members. This worked until a recent change to
cloudpickle upstream, but was likely much less efficient than it should have
been.

Now, `cloudpickle._core.unset_value` properly refers to the unset value
singleton, which implements `__reduce__` as `return
'cloudpickle._core.unset_value`, so it should serialize as a simple string and
import.