### PR TITLE
Fix segfault on py37 and add test

### DIFF
--- a/cloudpickle_generators/_core.c
+++ b/cloudpickle_generators/_core.c
@@ -223,7 +223,7 @@ private_frame_data(PyObject* UNUSED(self), PyObject* frame_ob) {
         PyTuple_SET_ITEM(block_stack, ix, block);
     }
 
-    if (!EXC_TYPE_REF(frame)) {
+    if (!EXC_TYPE_REF(frame) || (EXC_TYPE_REF(frame) == Py_None)) {
         if (EXC_VALUE_REF(frame) || EXC_TRACEBACK_REF(frame)) {
             PyErr_SetString(PyExc_AssertionError,
                             "the exception type was null but found non-null"

--- a/cloudpickle_generators/tests/test_segfault.py
+++ b/cloudpickle_generators/tests/test_segfault.py
@@ -9,12 +9,11 @@ def gen():
 
 
 def main():
-    subprocess.run(["ls"])
+    subprocess.check_call(["ls"])
     yield from gen()
-    
+
 
 def test_1():
     coro = main()
-    value = coro.send(None)    
+    coro.send(None)
     cloudpickle.dumps(coro)
-

--- a/cloudpickle_generators/tests/test_segfault.py
+++ b/cloudpickle_generators/tests/test_segfault.py
@@ -1,7 +1,5 @@
 import subprocess
 import cloudpickle
-import cloudpickle_generators
-cloudpickle_generators.register()
 
 
 def gen():

--- a/cloudpickle_generators/tests/test_segfault.py
+++ b/cloudpickle_generators/tests/test_segfault.py
@@ -1,0 +1,20 @@
+import subprocess
+import cloudpickle
+import cloudpickle_generators
+cloudpickle_generators.register()
+
+
+def gen():
+    return (yield 1)
+
+
+def main():
+    subprocess.run(["ls"])
+    yield from gen()
+    
+
+def test_1():
+    coro = main()
+    value = coro.send(None)    
+    cloudpickle.dumps(coro)
+


### PR DESCRIPTION
I don't understand exactly what's going on here, but I seem to be able to trigger a segfault (only tested on py37 on linux so far) by having a call to `subprocess` inside the generator.