### PR TITLE
BUG/DEV: Fix and test for a segfault during pickling of coroutines

### DIFF
--- a/cloudpickle_generators/_core.c
+++ b/cloudpickle_generators/_core.c
@@ -208,7 +208,7 @@ private_frame_data(PyObject* UNUSED(self), PyObject* frame_ob) {
     for (ix = 0; ix < size; ++ix) {
         PyObject* ob = frame->f_valuestack[ix];
         if (ob == NULL) {
-            ob = Py_None;
+            ob = &unset_value;
         }
         Py_INCREF(ob);
         PyTuple_SET_ITEM(stack, ix, ob);
@@ -313,7 +313,7 @@ restore_frame(PyObject* UNUSED(self), PyObject* args, PyObject* kwargs) {
     /* restore the data stack state */
     for (ix = 0; ix < PyTuple_Size(stack); ++ix) {
         PyObject* ob = PyTuple_GET_ITEM(stack, ix);
-        if (ob == Py_None) {
+        if (ob == &unset_value) {
             ob = NULL;
         }
         Py_XINCREF(ob);

--- a/cloudpickle_generators/_core.c
+++ b/cloudpickle_generators/_core.c
@@ -207,6 +207,9 @@ private_frame_data(PyObject* UNUSED(self), PyObject* frame_ob) {
 
     for (ix = 0; ix < size; ++ix) {
         PyObject* ob = frame->f_valuestack[ix];
+        if (ob == NULL) {
+            ob = Py_None;
+        }
         Py_INCREF(ob);
         PyTuple_SET_ITEM(stack, ix, ob);
     }
@@ -310,7 +313,10 @@ restore_frame(PyObject* UNUSED(self), PyObject* args, PyObject* kwargs) {
     /* restore the data stack state */
     for (ix = 0; ix < PyTuple_Size(stack); ++ix) {
         PyObject* ob = PyTuple_GET_ITEM(stack, ix);
-        Py_INCREF(ob);
+        if (ob == Py_None) {
+            ob = NULL;
+        }
+        Py_XINCREF(ob);
         *frame->f_stacktop++ = ob;
     }
 

--- a/cloudpickle_generators/tests/py35/test_coroutines.py
+++ b/cloudpickle_generators/tests/py35/test_coroutines.py
@@ -1,3 +1,4 @@
+import builtins
 from itertools import zip_longest
 from types import FunctionType, coroutine
 
@@ -157,3 +158,31 @@ def test_fully_consumed():
     gen.send(None)
 
     assert_roundtips(gen)
+
+
+def test_namespace_1():
+    class awaitable:
+        def __await__(self):
+            yield
+            return
+
+    async def f():
+        print(await awaitable())
+
+    gen = f()
+    gen.send(None)
+    cloudpickle.dumps(gen)
+
+
+def test_namespace_2():
+    class awaitable:
+        def __await__(self):
+            yield
+            return
+
+    async def f():
+        builtins.print(await awaitable())
+
+    gen = f()
+    gen.send(None)
+    cloudpickle.dumps(gen)

--- a/cloudpickle_generators/tests/py35/test_coroutines.py
+++ b/cloudpickle_generators/tests/py35/test_coroutines.py
@@ -1,4 +1,5 @@
 import builtins
+import pytest
 from itertools import zip_longest
 from types import FunctionType, coroutine
 
@@ -172,6 +173,9 @@ def test_namespace_1():
     gen = f()
     gen.send(None)
     cloudpickle.dumps(gen)
+    gen2 = cloudpickle.loads(cloudpickle.dumps(gen))
+    with pytest.raises(StopIteration):
+        gen2.send(None)
 
 
 def test_namespace_2():
@@ -185,4 +189,6 @@ def test_namespace_2():
 
     gen = f()
     gen.send(None)
-    cloudpickle.dumps(gen)
+    gen2 = cloudpickle.loads(cloudpickle.dumps(gen))
+    with pytest.raises(StopIteration):
+        gen2.send(None)


### PR DESCRIPTION
I will add a fix too, but I wanted to run this through the CI first.

On my python (3.7.4, linux), test_namespace_2 segfaults but test_namespace_1 is okay.

Also, while adding the test I realized that the tests for the coroutines have some room for improvement, because it looks like I forgot to advance the coroutines before checking that they roundtrip.