### PR TITLE
Support python 3.8 to 3.10

### DIFF
--- a/cloudpickle_generators/__init__.py
+++ b/cloudpickle_generators/__init__.py
@@ -221,29 +221,86 @@ def _save_generator_impl(self, frame, gen, filler):
     write(pickle.REDUCE)
 
 
+# The _reduce.*() variants work with the C implementation of pickle, which
+# became the default from Python 3.8.
+def _reduce_generator(gen):
+    if gen.gi_running:
+        raise ValueError("cannot save running generator")
+
+    frame = gen.gi_frame
+    return _reduce_generator_impl(frame, gen, _fill_generator)
+
+
+def _reduce_coroutine(coro):
+    frame = coro.cr_frame
+    return _reduce_generator_impl(frame, coro, _fill_coroutine)
+
+
+def _reduce_async_generator(asyncgen):
+    frame = asyncgen.ag_frame
+    return _reduce_generator_impl(frame, asyncgen, _fill_async_generator)
+
+
+def _reduce_generator_impl(frame, gen, filler):
+    if frame is None:
+        # frame is None when the generator is fully consumed; take a fast path
+        return _restore_spent_generator, (
+            gen.__name__,
+            getattr(gen, "__qualname__", None),
+        )
+
+    f_code = frame.f_code
+
+    # Create a copy of generator function without the closure to serve as a box
+    # to serialize the code, globals, name, and closure. Cloudpickle already
+    # handles things like closures and complicated globals so just rely on
+    # cloudpickle to serialize this function.
+    gen_func = FunctionType(
+        f_code,
+        frame.f_globals,
+        gen.__name__,
+        (),
+        (_empty_cell(),) * len(f_code.co_freevars),
+    )
+    gen_func.__qualname__ = gen.__qualname__
+
+    return (
+        _create_skeleton_generator,
+        (gen_func,),
+        (frame.f_lasti, frame.f_locals, private_frame_data(frame)),
+        None,
+        None,
+        lambda obj, state: filler(obj, *state),
+    )
+
+
 def register():
     """Register the cloudpickle extension.
     """
-    CloudPickler.dispatch[GeneratorType] = _save_generator
-    if sys.version_info >= (3, 5, 0):
-        CloudPickler.dispatch[CoroutineType] = _save_coroutine
-    if sys.version_info >= (3, 6, 0):
-        CloudPickler.dispatch[AsyncGeneratorType] = _save_async_generator
+    if pickle.HIGHEST_PROTOCOL >= 5:
+        CloudPickler.dispatch[GeneratorType] = _reduce_generator
+        CloudPickler.dispatch[CoroutineType] = _reduce_coroutine
+        CloudPickler.dispatch[AsyncGeneratorType] = _reduce_async_generator
+    else:
+        CloudPickler.dispatch[GeneratorType] = _save_generator
+        if sys.version_info >= (3, 5, 0):
+            CloudPickler.dispatch[CoroutineType] = _save_coroutine
+        if sys.version_info >= (3, 6, 0):
+            CloudPickler.dispatch[AsyncGeneratorType] = _save_async_generator
 
 
 def unregister():
     """Unregister the cloudpickle extension.
     """
-    if CloudPickler.dispatch.get(GeneratorType) is _save_generator:
+    if CloudPickler.dispatch.get(GeneratorType) in [_save_generator, _reduce_generator]:
         # make sure we are only removing the dispatch we added, not someone
         # else's
         del CloudPickler.dispatch[GeneratorType]
 
     if sys.version_info >= (3, 5, 0):
-        if CloudPickler.dispatch.get(CoroutineType) is _save_coroutine:
+        if CloudPickler.dispatch.get(CoroutineType) is [_save_coroutine, _reduce_coroutine]:
             del CloudPickler.dispatch[CoroutineType]
 
     if sys.version_info >= (3, 6, 0):
-        if (CloudPickler.dispatch.get(AsyncGeneratorType) is
-                _save_async_generator):
+        if CloudPickler.dispatch.get(AsyncGeneratorType) in [_save_async_generator, _reduce_async_generator]:
             del CloudPickler.dispatch[AsyncGeneratorType]

--- a/cloudpickle_generators/tests/py36/test_async_generators.py
+++ b/cloudpickle_generators/tests/py36/test_async_generators.py
@@ -2,6 +2,8 @@ from itertools import zip_longest
 from types import FunctionType, coroutine
 
 import cloudpickle
+import pytest
+import sys
 
 
 @coroutine
@@ -57,6 +59,7 @@ def test_async_generator_0():
         yield 2
 
 
+@pytest.mark.xfail(sys.version_info >= (3, 8, 0), reason="asyncgen_asgen doesn't work on this function before roundtrip")
 def test_async_generator_1():
     async def ticker(delay, to):
         # PEP525


### PR DESCRIPTION
The python 3.8 support is partly based on #14. All (but one; see below) tests
pass in python 3.7 to python 3.10 (I haven't tested earlier version but I don't
expect them to fail)

`test_async_generator_1` fails in python 3.8, but I believe this is not related
to `cloudpickle-generators` at all; the `asyncgen_asgen` function fails to
convert the original async generator into a generator (even before the
cloudpickle roundtrip). I haven't looked too deeply into this, but I think that
should be addressed in a separate PR/issue.

Python 3.11 support would require a lot more work, as the internals of frame
objects was reworked.
